### PR TITLE
Modify unavailable property syntax to resolve errors building for iOS 17 on Xcode 15

### DIFF
--- a/Research/ResearchUI/iOS/Views/RSDRoundedButton.swift
+++ b/Research/ResearchUI/iOS/Views/RSDRoundedButton.swift
@@ -102,7 +102,7 @@ import UIKit
     
     // TODO: syoung 03/19/2019 Remove these properties once the modules that use them have been updated.
     @available(*, unavailable)
-    open var usesLightStyle: Bool = false
+	open var usesLightStyle: Bool { return false }
     
     /// Should the button display using the "secondary" button style? This style is used for buttons that
     /// are displayed inline with scrolling views for handling secondary actions.

--- a/Research/ResearchUI/iOS/Views/RSDRoundedButton.swift
+++ b/Research/ResearchUI/iOS/Views/RSDRoundedButton.swift
@@ -102,7 +102,7 @@ import UIKit
     
     // TODO: syoung 03/19/2019 Remove these properties once the modules that use them have been updated.
     @available(*, unavailable)
-	open var usesLightStyle: Bool { return false }
+    open var usesLightStyle: Bool { return false }
     
     /// Should the button display using the "secondary" button style? This style is used for buttons that
     /// are displayed inline with scrolling views for handling secondary actions.

--- a/Research/ResearchUI/iOS/Views/RSDStepNavigationView.swift
+++ b/Research/ResearchUI/iOS/Views/RSDStepNavigationView.swift
@@ -155,7 +155,7 @@ open class RSDStepNavigationView: UIView, RSDViewDesignable {
     /// Should the navigation view subcomponents be displayed with a dark background and light tint on the
     /// buttons and text?
     @available(*, unavailable)
-    open var usesLightStyle: Bool = false
+	open var usesLightStyle: Bool { return false }
     
     /// The background color mapping that this view should use as its key.
     open private(set) var backgroundColorTile: RSDColorTile?

--- a/Research/ResearchUI/iOS/Views/RSDStepNavigationView.swift
+++ b/Research/ResearchUI/iOS/Views/RSDStepNavigationView.swift
@@ -155,7 +155,7 @@ open class RSDStepNavigationView: UIView, RSDViewDesignable {
     /// Should the navigation view subcomponents be displayed with a dark background and light tint on the
     /// buttons and text?
     @available(*, unavailable)
-	open var usesLightStyle: Bool { return false }
+    open var usesLightStyle: Bool { return false }
     
     /// The background color mapping that this view should use as its key.
     open private(set) var backgroundColorTile: RSDColorTile?

--- a/Research/ResearchUI/iOS/Views/RSDStepProgressView.swift
+++ b/Research/ResearchUI/iOS/Views/RSDStepProgressView.swift
@@ -54,13 +54,13 @@ open class RSDStepProgressView: UIView, RSDViewDesignable {
     
     // TODO: syoung 03/19/2019 Remove these properties once the modules that use them have been updated.
     @available(*, unavailable)
-    open var usesLightStyle: Bool = false
+	open var usesLightStyle: Bool { return false }
     
     @available(*, unavailable)
-    open var labelIsUppercase: Bool = false
+	open var labelIsUppercase: Bool { return false }
     
     @available(*, unavailable)
-    open var labelCurrentStepIsBold: Bool = false
+	open var labelCurrentStepIsBold: Bool { return false }
     
     /// The background color mapping that this view should use as its key. Typically, for all but the
     /// top-level views, this will be the background of the superview.

--- a/Research/ResearchUI/iOS/Views/RSDStepProgressView.swift
+++ b/Research/ResearchUI/iOS/Views/RSDStepProgressView.swift
@@ -54,13 +54,13 @@ open class RSDStepProgressView: UIView, RSDViewDesignable {
     
     // TODO: syoung 03/19/2019 Remove these properties once the modules that use them have been updated.
     @available(*, unavailable)
-	open var usesLightStyle: Bool { return false }
+    open var usesLightStyle: Bool { return false }
     
     @available(*, unavailable)
-	open var labelIsUppercase: Bool { return false }
+    open var labelIsUppercase: Bool { return false }
     
     @available(*, unavailable)
-	open var labelCurrentStepIsBold: Bool { return false }
+    open var labelCurrentStepIsBold: Bool { return false }
     
     /// The background color mapping that this view should use as its key. Typically, for all but the
     /// top-level views, this will be the background of the superview.


### PR DESCRIPTION
## What type of change is this?

- [x] 🐛 Bug Fix

## Describe the change

Modify unavailable property syntax to resolve errors building for iOS 17 on Xcode 15. This was the only break-fix required to build MyCap on iOS 17


## Pivotal Tracker Link

https://www.pivotaltracker.com/story/show/185707706

## How was the change tested?

Tested by: running MyCap unit tests, running on simulator and device using iOS 17 - also this fixes the build errors on iOS 17

## Are there any dependencies needed for this change to work?

No

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [-] I have commented my code to provide insight on any hard-to-understand areas
- [-] I have made corresponding changes to any related documentation
- [x] My changes generate no new warnings
- [-] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [-] Any dependent changes have been merged and published in downstream modules
