### PR TITLE
Add new property to inject config for UI Testing

### DIFF
--- a/Research/ResearchUI/iOS/RSDStepViewController.swift
+++ b/Research/ResearchUI/iOS/RSDStepViewController.swift
@@ -84,6 +84,12 @@ open class RSDStepViewController : UIViewController, RSDStepController, RSDCance
             return result
         }
     }()
+
+    /// Property for supplying a callback that will be called during the view controller's `viewDidLoad()`.
+    ///
+    /// This is currently used by UI testing to inject custom view configuration required for testing.
+    /// - parameter viewController: A reference to the view controller whose view was loaded.
+    public var callback_onViewDidLoad: ((_ viewController: RSDStepViewController) -> Void)? = nil
     
     // MARK: Initialization
     


### PR DESCRIPTION
## What type of change is this?

- [x] 📦 Chore

## Describe the change

This change adds a new closure property to `RSDStepViewController`.  

The new property provides UI Testing (and potentially other clients, should they desire it) the ability to inject custom config to run on viewDidLoad.

## Pivotal Tracker Link

https://www.pivotaltracker.com/story/show/186560767


## How was the change tested?

There don't seem to be any unit tests specific to this library.  Locally run unit/UI tests for dependent products (MobileToolbox) passed.

## Are there any dependencies needed for this change to work?

This change doesn't have any dependencies, but another changeset for MobileToolbox will depend on this change.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code to provide insight on any hard-to-understand areas
- [x] I have made corresponding changes to any related documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
